### PR TITLE
chore: update Visual Data Preparation to Versatile Data Pipeline

### DIFF
--- a/.github/workflows/add-issue-to-prj.yml
+++ b/.github/workflows/add-issue-to-prj.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.botGitHubToken }}
           ORGANIZATION: instill-ai
-          PROJECT_NUMBER: 5  # Visual Data Preparation (VDP) project
+          PROJECT_NUMBER: 5 # Versatile Data Pipeline (VDP) project
         run: |
           gh api graphql -f query='
             query($org: String!, $number: Int!) {

--- a/.github/workflows/add-pr-to-prj.yml
+++ b/.github/workflows/add-pr-to-prj.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.botGitHubToken }}
           ORGANIZATION: instill-ai
-          PROJECT_NUMBER: 5  # Visual Data Preparation (VDP) project
+          PROJECT_NUMBER: 5 # Versatile Data Pipeline (VDP) project
         run: |
           gh api graphql -f query='
             query($org: String!, $number: Int!) {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -9,10 +9,9 @@ repos:
           (?x)(
             ^pkg/export/filter_test.go
           )
-  - repo: git://github.com/dnephin/pre-commit-golang
-    rev: v0.4.0
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
     hooks:
-      - id: go-fmt
       - id: golangci-lint
       - id: go-mod-tidy
   - repo: https://github.com/pinglin/conventional-pre-commit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img src="https://raw.githubusercontent.com/instill-ai/.github/main/img/cli.png" alt="Instill AI - Visual Data Preparation Made for All" />
+  <img src="https://raw.githubusercontent.com/instill-ai/.github/main/img/cli.png" alt="Instill AI - Unstructured Data ETL Made for All" />
 </h1>
 
 <h4 align="center">
@@ -27,9 +27,9 @@
 
 ## What is Instill Cloud?
 
-Instill AI is on a mission to make Vision AI accessible to everyone. With **Instill Cloud**, one can easily build up a data pipeline to transform unstructured visual data to structured data, starting to tap on the value of visual data.
+Instill AI is on a mission to make AI accessible to everyone. With **Instill Cloud**, one can easily build up a data pipeline to transform unstructured data to meaningful data representations, starting to tap on the value of unstructured data.
 
-**Instill Cloud** provides a **Pipeline** consisting of **Data Connector**, **Visual Data Operator** and **Logic Operator** components, to process unstructured visual data to their structured representation.
+**Instill Cloud** provides a **Pipeline** consisting of **Source Connector**, **Model**, **Logic Operator** and **Destination Connector** components, to process unstructured data to their meaningful data representations.
 
 ## Installation
 


### PR DESCRIPTION
Because

- instead of Visual Data Preparation, VDP is Versatile Data Pipeline now. We realise that as a general ETL infrastructure, VDP is capable of processing all kinds of unstructured data, and we should not limit its usage to only visual data. That's why we replace the word Visual with Versatile. Besides, the term Data Preparation is a bit misleading, users often think it has something to do with data labelling or cleaning. The term Data Pipeline is definitely more precise to capture the core concept of VDP.
 
This commit

- update pre-commit 
- update to Versatile Data Pipeline
