### PR TITLE
refactor(auth): remove .env file import logic

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -31,9 +31,3 @@ jobs:
           # secrets
           INSTILL_OAUTH_CLIENT_ID: ${{ secrets.oauth2ClientId }}
           INSTILL_OAUTH_CLIENT_SECRET: ${{ secrets.oauth2ClientSecret }}
-          # config
-          INSTILL_OAUTH_ISSUER: ${{ vars.INSTILL_OAUTH_ISSUER }}
-          INSTILL_OAUTH_HOSTNAME: ${{ vars.INSTILL_OAUTH_HOSTNAME }}
-          INSTILL_OAUTH_AUDIENCE: ${{ vars.INSTILL_OAUTH_AUDIENCE }}
-          INSTILL_OAUTH_CALLBACK_HOST: ${{ vars.INSTILL_OAUTH_CALLBACK_HOST }}
-          INSTILL_OAUTH_CALLBACK_PORT: ${{ vars.INSTILL_OAUTH_CALLBACK_PORT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,11 +23,6 @@ builds:
         - -X github.com/instill-ai/cli/internal/build.Date={{ time "2006-01-02" }}
         - -X github.com/instill-ai/cli/internal/oauth2.clientID={{ .Env.INSTILL_OAUTH_CLIENT_ID }}
         - -X github.com/instill-ai/cli/internal/oauth2.clientSecret={{ .Env.INSTILL_OAUTH_CLIENT_SECRET }}
-        - -X github.com/instill-ai/cli/internal/oauth2.issuer={{ .Env.INSTILL_OAUTH_ISSUER }}
-        - -X github.com/instill-ai/cli/internal/oauth2.hostname={{ .Env.INSTILL_OAUTH_HOSTNAME }}
-        - -X github.com/instill-ai/cli/internal/oauth2.audience={{ .Env.INSTILL_OAUTH_AUDIENCE }}
-        - -X github.com/instill-ai/cli/internal/oauth2.callbackHost={{ .Env.INSTILL_OAUTH_CALLBACK_HOST }}
-        - -X github.com/instill-ai/cli/internal/oauth2.callbackPort={{ .Env.INSTILL_OAUTH_CALLBACK_PORT }}
         - -X main.updaterEnabled=instill-ai/cli
     id: macos
     goos: [darwin]
@@ -61,7 +56,7 @@ archives:
         format: zip
 
 checksum:
-  name_template: 'checksums_v{{ .Version }}_sha256.txt'
+  name_template: "checksums_v{{ .Version }}_sha256.txt"
 
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
@@ -73,7 +68,7 @@ changelog:
     - title: Features
       regexp: "^.*feat[(\\w)]*:+.*$"
       order: 0
-    - title: 'Bug fixes'
+    - title: "Bug fixes"
       regexp: "^.*fix[(\\w)]*:+.*$"
       order: 1
 

--- a/cmd/instill/main.go
+++ b/cmd/instill/main.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	surveyCore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/cli/safeexec"
 	"github.com/dotenv-org/godotenvvault"
@@ -19,10 +18,11 @@ import (
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
 
+	surveyCore "github.com/AlecAivazis/survey/v2/core"
+
 	"github.com/instill-ai/cli/api"
 	"github.com/instill-ai/cli/internal/build"
 	"github.com/instill-ai/cli/internal/config"
-	"github.com/instill-ai/cli/internal/oauth2"
 	"github.com/instill-ai/cli/internal/update"
 	"github.com/instill-ai/cli/pkg/cmd/factory"
 	"github.com/instill-ai/cli/pkg/cmd/root"
@@ -115,19 +115,6 @@ func mainRun() exitCode {
 
 	authError := errors.New("authError")
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		// in case there's no hosts.yml config, create one with the default instance
-		f, err := os.Stat(config.HostsConfigFile())
-		exists := err == nil && !f.IsDir()
-		if !exists {
-			// get the (hardcoded) default cloud instance
-			host := oauth2.HostConfigInstillCloud()
-			err = cfg.SaveTyped(host)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(stderr, cs.Bold("No host.yml config, creating a default one..."))
-			fmt.Fprintln(stderr, config.HostsConfigFile())
-		}
 		// require that the user is authenticated before running most commands
 		if cmdutil.IsAuthCheckEnabled(cmd) && !cmdutil.CheckAuth(cfg) {
 			fmt.Fprintln(stderr, cs.Bold("Welcome to Instill CLI!"))

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -66,6 +66,7 @@ func (c ConfigStub) MakeConfigForHost(hostname string) *HostConfig {
 }
 
 func (c ConfigStub) HostsTyped() ([]HostConfigTyped, error) {
+
 	ins := []HostConfigTyped{
 		{
 			APIHostname:        "api.instill.tech",

--- a/internal/oauth2/auth_code_flow.go
+++ b/internal/oauth2/auth_code_flow.go
@@ -71,7 +71,7 @@ func NewAuthenticator(issuer, clientID, clientSecret, callbackHost string, callb
 		ClientSecret: clientSecret,
 		Endpoint:     provider.Endpoint(),
 		RedirectURL:  fmt.Sprintf("http://%s:%d/%s", callbackHost, callbackPort, "callback"),
-		Scopes:       []string{"offline", "openid", "email", "profile"},
+		Scopes:       []string{"offline_access", "openid", "email", "profile"},
 	}
 
 	return &Authenticator{
@@ -142,6 +142,7 @@ func AuthCodeFlowWithConfig(f *cmdutil.Factory, host *config.HostConfigTyped, cf
 	// TODO use HostConfigTyped
 	host.TokenType = token.Type()
 	host.AccessToken = token.AccessToken
+	host.RefreshToken = token.RefreshToken
 	host.Expiry = token.Expiry.Format(time.RFC1123)
 	host.IDToken = token.Extra("id_token").(string)
 	if err := cfg.SaveTyped(host); err != nil {

--- a/internal/oauth2/refresh_token.go
+++ b/internal/oauth2/refresh_token.go
@@ -11,11 +11,23 @@ import (
 func RefreshToken(cfg iconfig, hostname string) (string, error) {
 
 	var (
-		accessToken  string
-		refreshToken string
-		expiry       time.Time
-		err          error
+		oauth2ClientID     string
+		oauth2ClientSecret string
+		accessToken        string
+		refreshToken       string
+		expiry             time.Time
+		err                error
 	)
+
+	oauth2ClientID, err = cfg.Get(hostname, "oauth2_client_id")
+	if err != nil {
+		return "", err
+	}
+
+	oauth2ClientSecret, err = cfg.Get(hostname, "oauth2_client_secret")
+	if err != nil {
+		return "", err
+	}
 
 	accessToken, err = cfg.Get(hostname, "access_token")
 	if err != nil {
@@ -42,8 +54,8 @@ func RefreshToken(cfg iconfig, hostname string) (string, error) {
 	}
 
 	conf := &oauth2.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
+		ClientID:     oauth2ClientID,
+		ClientSecret: oauth2ClientSecret,
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  fmt.Sprintf("https://auth.%s/oauth2/auth", hostname),
 			TokenURL: fmt.Sprintf("https://auth.%s/oauth2/token", hostname),

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -2,13 +2,16 @@ package login
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 
+	"github.com/instill-ai/cli/internal/build"
 	"github.com/instill-ai/cli/internal/config"
 	"github.com/instill-ai/cli/internal/oauth2"
+	"github.com/instill-ai/cli/pkg/cmd/factory"
 	"github.com/instill-ai/cli/pkg/cmdutil"
 	"github.com/instill-ai/cli/pkg/iostreams"
 	"github.com/instill-ai/cli/pkg/prompt"
@@ -65,27 +68,51 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 }
 
 func loginRun(f *cmdutil.Factory, opts *LoginOptions) error {
+
+	var host *config.HostConfigTyped
+
 	cfg, err := opts.Config()
 	if err != nil {
 		return err
 	}
 
-	hostname := opts.Hostname
-
-	hosts, err := cfg.HostsTyped()
-	if err != nil {
-		return err
-	}
-
-	var host *config.HostConfigTyped
-	for _, h := range hosts {
-		if h.APIHostname == hostname {
-			host = &h
-			break
+	// in case there's no hosts.yml config, create one with the default instance
+	fs, err := os.Stat(config.HostsConfigFile())
+	if !(err == nil && !fs.IsDir()) {
+		// get the (hardcoded) default cloud instance
+		host = oauth2.HostConfigInstillCloud()
+		err = cfg.SaveTyped(host)
+		if err != nil {
+			return err
 		}
-	}
-	if host == nil {
-		return fmt.Errorf("ERROR: instance '%s' does not exists", hostname)
+
+		cmdFactory := factory.New(build.Version)
+		stderr := cmdFactory.IOStreams.ErrOut
+		cs := cmdFactory.IOStreams.ColorScheme()
+
+		fmt.Fprintln(stderr, cs.Bold("No host.yml config, creating one with the default host \"api.instill.tech\"..."))
+		fmt.Fprintln(stderr, config.HostsConfigFile())
+		fmt.Fprintln(stderr, "")
+	} else {
+
+		hostname := opts.Hostname
+
+		hosts, err := cfg.HostsTyped()
+		if err != nil {
+			return err
+		}
+
+		for _, h := range hosts {
+			if h.APIHostname == hostname {
+				host = &h
+				break
+			}
+		}
+
+		if host == nil {
+			return fmt.Errorf("ERROR: instance '%s' does not exists", hostname)
+		}
+
 	}
 
 	if host.Oauth2Hostname == "" || host.Oauth2ClientID == "" || host.Oauth2ClientSecret == "" {
@@ -95,7 +122,7 @@ func loginRun(f *cmdutil.Factory, opts *LoginOptions) error {
 			$ instill instances edit %s \
 				--oauth2 HOSTNAME \
 				--client-id CLIENT_ID \
-				--client-secret CLIENT_SECRET`, hostname, hostname)
+				--client-secret CLIENT_SECRET`, host.APIHostname, host.APIHostname)
 		return fmt.Errorf(e)
 	}
 
@@ -104,7 +131,7 @@ func loginRun(f *cmdutil.Factory, opts *LoginOptions) error {
 		err = prompt.SurveyAskOne(&survey.Confirm{
 			Message: fmt.Sprintf(
 				"You're already logged into %s. Do you want to re-authenticate?",
-				hostname),
+				host.APIHostname),
 			Default: false,
 		}, &keepGoing)
 		if err != nil {

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -95,7 +95,7 @@ func loginRun(f *cmdutil.Factory, opts *LoginOptions) error {
 			$ instill instances edit %s \
 				--oauth2 HOSTNAME \
 				--client-id CLIENT_ID \
-				--client-secret SECRET`, hostname, hostname)
+				--client-secret CLIENT_SECRET`, hostname, hostname)
 		return fmt.Errorf(e)
 	}
 

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -7,9 +7,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/instill-ai/cli/internal/config"
+	"github.com/instill-ai/cli/pkg/cmdutil"
+
 	cmdGet "github.com/instill-ai/cli/pkg/cmd/config/get"
 	cmdSet "github.com/instill-ai/cli/pkg/cmd/config/set"
-	"github.com/instill-ai/cli/pkg/cmdutil"
 )
 
 func NewCmdConfig(f *cmdutil.Factory) *cobra.Command {


### PR DESCRIPTION
Because

- OAuth2 client-credential flow callback to a local machine can use a constant URL `http://localhost:8085`

- `client-id` and `client-secret` for production `api.instill.tech` are injected during build/installation time by:
```
$ INSTILL_OAUTH_CLIENT_ID=<client-id> INSTILL_OAUTH_CLIENT_SECRET=<client-secret> make install
```

For internal maintenance only - We can still set staging and dev Instill Cloud with the corresponding `client-id` and `client-secret` through
```
$ ./bin/instill instances add <staging-api-url> \      
  --oauth2 <staging-auth-url> \
  --audience <staging-api-url> \
  --issuer <staging-api-url>/ \
  --client-secret <staging-client-secret> \
  --client-id <staging-client-id>
```

This commit

- hardcode OAuth2 callback URL
- remove unused global static variables for `internal/oauth2`
- fix `auth login` right after installation error
- fix missing refresh token
