### PR TITLE
fix: handle API prefixes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up Go 1.20
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.20
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go 1.20
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ $ instill auth login
 $ instill api pipelines
 
 # list models
-$ instill api models
+$ instill api model/models
 
 # add parameters to a GET request
-$ instill api models?visibility=public
+$ instill api model/models?visibility=public
 
 # list instances
 $ instill instances list

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -694,3 +694,37 @@ func Test_processResponse_template(t *testing.T) {
 	`), stdout.String())
 	assert.Equal(t, "", stderr.String())
 }
+
+func TestHandleAPIPrefix(t *testing.T) {
+	tests := []struct {
+		path     string
+		version  string
+		expected string
+	}{
+		{
+			path:     "foo",
+			version:  "1",
+			expected: "vdp/1/foo",
+		},
+		{
+			path:     "model/foo",
+			version:  "1",
+			expected: "model/1/foo",
+		},
+		{
+			path:     "base/foo",
+			version:  "1",
+			expected: "base/1/foo",
+		},
+		{
+			path:     "vdp/foo",
+			version:  "1",
+			expected: "vdp/1/foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version+"/"+tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.expected, handleAPIPrefix(tt.path, tt.version))
+		})
+	}
+}


### PR DESCRIPTION
Because

- currently, only the `/vdp` prefix is supported

This commit

- adds support for `model` and `base`, while defaulting to `vdp` for unprefixed calls 
