### PR TITLE
feat(local): complete deploy/undeploy cycle for local instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,10 @@ clean:
 # just a convenience task around `go test`
 .PHONY: test
 test:
-	go test -race ./...
-
+	@go test -v -race -coverpkg=./... -coverprofile=coverage.out ./...
+	@go tool cover -func=coverage.out
+	@go tool cover -html=coverage.out
+	@rm coverage.out
 ## Install/uninstall tasks are here for use on *nix platform. On Windows, there is no equivalent.
 DESTDIR :=
 prefix  := /usr/local

--- a/cmd/instill/main.go
+++ b/cmd/instill/main.go
@@ -238,10 +238,10 @@ func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
 
 	repo := updaterEnabled
 	stateFilePath := filepath.Join(config.StateDir(), "state.yml")
-	return update.CheckForUpdate(client, stateFilePath, repo, currentVersion)
+	return update.CheckForUpdate(client, stateFilePath, repo, currentVersion, false)
 }
 
-// BasicClient returns an API client for instill.tech only that borrows from but
+// basicClient returns an API client for instill.tech only that borrows from but
 // does not depend on user configuration
 func basicClient(currentVersion string) (*api.Client, error) {
 	var opts []api.ClientOption

--- a/cmd/instill/main.go
+++ b/cmd/instill/main.go
@@ -238,7 +238,7 @@ func checkForUpdate(currentVersion string) (*update.ReleaseInfo, error) {
 
 	repo := updaterEnabled
 	stateFilePath := filepath.Join(config.StateDir(), "state.yml")
-	return update.CheckForUpdate(client, stateFilePath, repo, currentVersion, false)
+	return update.CheckForUpdate(client, stateFilePath, repo, currentVersion)
 }
 
 // basicClient returns an API client for instill.tech only that borrows from but

--- a/cmd/instill/main.go
+++ b/cmd/instill/main.go
@@ -168,7 +168,7 @@ func mainRun() exitCode {
 			return exitOK
 		}
 		fmt.Fprintf(stderr, "\n\n%s %s → %s\n",
-			ansi.Color("A new release of instill is available:", "yellow"),
+			ansi.Color("A new release of Instill CLI is available:", "yellow"),
 			ansi.Color(buildVersion, "cyan"),
 			ansi.Color(newRelease.Version, "cyan"))
 		if isHomebrew {

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -60,7 +60,7 @@ func StateDir() string {
 		path = filepath.Join(b, "Instill CLI")
 	} else {
 		c, _ := os.UserHomeDir()
-		path = filepath.Join(c, ".local", "state", "instill")
+		path = filepath.Join(c, ".local", "instill", "state")
 	}
 
 	// If the path does not exist try migrating state from default paths

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -366,7 +366,7 @@ func Test_StateDir(t *testing.T) {
 				"USERPROFILE":        tempDir,
 				"HOME":               tempDir,
 			},
-			output: filepath.Join(tempDir, ".local", "state", "instill"),
+			output: filepath.Join(tempDir, ".local", "instill", "state"),
 		},
 		{
 			name: "XDG_STATE_HOME specified",
@@ -462,7 +462,7 @@ func Test_autoMigrateStateDir_migration(t *testing.T) {
 	homeDir := t.TempDir()
 	migrateDir := t.TempDir()
 	homeConfigDir := filepath.Join(homeDir, ".config", "instill")
-	migrateStateDir := filepath.Join(migrateDir, ".local", "state", "instill")
+	migrateStateDir := filepath.Join(migrateDir, ".local", "instill")
 
 	homeEnvVar := "HOME"
 	if runtime.GOOS == "windows" {

--- a/internal/config/from_file_test.go
+++ b/internal/config/from_file_test.go
@@ -24,7 +24,7 @@ func Test_HostsTyped(t *testing.T) {
 }
 
 func Test_fileConfig_Typed(t *testing.T) {
-	configDir := filepath.Join(t.TempDir(), ".config", "instill")
+	configDir := filepath.Join(t.TempDir(), ".local", "instill")
 	_ = os.MkdirAll(configDir, 0755)
 	os.Setenv(INSTILL_CONFIG_DIR, configDir)
 	defer os.Unsetenv(INSTILL_CONFIG_DIR)

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -82,7 +82,7 @@ func TestCheckForUpdate(t *testing.T) {
 				}`, s.LatestVersion, s.LatestURL)),
 			)
 
-			rel, err := CheckForUpdate(client, tempFilePath(), "OWNER/REPO", s.CurrentVersion, false)
+			rel, err := CheckForUpdate(client, tempFilePath(), "OWNER/REPO", s.CurrentVersion)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -82,7 +82,7 @@ func TestCheckForUpdate(t *testing.T) {
 				}`, s.LatestVersion, s.LatestURL)),
 			)
 
-			rel, err := CheckForUpdate(client, tempFilePath(), "OWNER/REPO", s.CurrentVersion)
+			rel, err := CheckForUpdate(client, tempFilePath(), "OWNER/REPO", s.CurrentVersion, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -53,7 +53,7 @@ var logger *slog.Logger
 
 func init() {
 	var lvl = new(slog.LevelVar)
-	if os.Getenv("INSTILL_DEBUG") != "" {
+	if os.Getenv("DEBUG") != "" {
 		lvl.Set(slog.LevelDebug)
 	} else {
 		lvl.Set(slog.LevelError + 1)

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -17,10 +17,11 @@ import (
 	"github.com/instill-ai/cli/internal/instance"
 	"github.com/instill-ai/cli/internal/oauth2"
 	"github.com/instill-ai/cli/pkg/cmd/factory"
-	instances "github.com/instill-ai/cli/pkg/cmd/local"
 	"github.com/instill-ai/cli/pkg/cmdutil"
 	"github.com/instill-ai/cli/pkg/iostreams"
 	"github.com/instill-ai/cli/pkg/prompt"
+
+	"github.com/instill-ai/cli/pkg/cmd/local"
 )
 
 type LoginOptions struct {
@@ -186,7 +187,7 @@ type localLoginRequest struct {
 func loginLocal(transport http.RoundTripper, hostname, password string) (string, error) {
 	url := instance.GetProtocol(hostname) + "base/v1alpha/auth/login"
 	data := &localLoginRequest{
-		Name: instances.DefUsername,
+		Name: local.DefUsername,
 		Pass: password,
 	}
 	jsonData, err := json.Marshal(data)

--- a/pkg/cmd/instances/remove.go
+++ b/pkg/cmd/instances/remove.go
@@ -60,14 +60,14 @@ func NewRemoveCmd(f *cmdutil.Factory, runF func(*RemoveOptions) error) *cobra.Co
 				return runF(opts)
 			}
 
-			return runRemove(opts)
+			return RunRemove(opts)
 		},
 	}
 
 	return cmd
 }
 
-func runRemove(opts *RemoveOptions) error {
+func RunRemove(opts *RemoveOptions) error {
 	hosts, err := opts.Config.HostsTyped()
 	if err != nil {
 		return err

--- a/pkg/cmd/local/deploy_test.go
+++ b/pkg/cmd/local/deploy_test.go
@@ -19,7 +19,7 @@ func TestLocalDeployCmd(t *testing.T) {
 	if err != nil {
 		logger.Error("Couldn't get home directory", err)
 	}
-	dir := filepath.Join(d, ".config", "instill") + string(os.PathSeparator)
+	dir := filepath.Join(d, ".local", "instill") + string(os.PathSeparator)
 	tests := []struct {
 		name     string
 		stdin    string
@@ -32,8 +32,7 @@ func TestLocalDeployCmd(t *testing.T) {
 			name:  "no arguments",
 			input: "",
 			output: DeployOptions{
-				Path:   dir,
-				Branch: "main",
+				Path: dir,
 			},
 			isErr: false,
 		},
@@ -41,8 +40,7 @@ func TestLocalDeployCmd(t *testing.T) {
 			name:  "local deploy --path /home",
 			input: " --path /home",
 			output: DeployOptions{
-				Path:   "/home",
-				Branch: "main",
+				Path: "/home",
 			},
 			isErr: false,
 		},
@@ -88,7 +86,6 @@ func TestLocalDeployCmd(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.output.Path, gotOpts.Path)
-			assert.Equal(t, tt.output.Branch, gotOpts.Branch)
 		})
 	}
 }
@@ -100,7 +97,7 @@ func TestLocalDeployCmdRun(t *testing.T) {
 	if err != nil {
 		logger.Error("Couldn't get home directory", err)
 	}
-	dir := filepath.Join(d, ".config", "instill") + string(os.PathSeparator)
+	dir := filepath.Join(d, ".local", "instill") + string(os.PathSeparator)
 	tests := []struct {
 		name     string
 		input    *DeployOptions
@@ -113,12 +110,11 @@ func TestLocalDeployCmdRun(t *testing.T) {
 			name: "local deploy",
 			input: &DeployOptions{
 				Path:   dir,
-				Branch: "main",
 				Exec:   execMock,
 				OS:     osMock,
 				Config: config.ConfigStub{},
 			},
-			stdout: "Instill Core console available under http://localhost:3000",
+			stdout: "",
 			isErr:  false,
 		},
 	}

--- a/pkg/cmd/local/deploy_test.go
+++ b/pkg/cmd/local/deploy_test.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -90,6 +91,10 @@ func TestLocalDeployCmd(t *testing.T) {
 	}
 }
 
+func checkFoUpdateMock(ExecDep, string, string) (*releaseInfo, error) {
+	return &releaseInfo{}, nil
+}
+
 func TestLocalDeployCmdRun(t *testing.T) {
 	execMock := &ExecMock{}
 	osMock := &OSMock{}
@@ -109,13 +114,62 @@ func TestLocalDeployCmdRun(t *testing.T) {
 		{
 			name: "local deploy",
 			input: &DeployOptions{
-				Path:   dir,
-				Exec:   execMock,
-				OS:     osMock,
-				Config: config.ConfigStub{},
+				Path:        dir,
+				Exec:        execMock,
+				OS:          osMock,
+				Config:      config.ConfigStub{},
+				checkUpdate: checkFoUpdateMock,
+				isDeployed: func(ed ExecDep) error {
+					return nil
+				},
 			},
 			stdout: "",
 			isErr:  false,
+		},
+		{
+			name: "local deploy",
+			input: &DeployOptions{
+				Path:        dir,
+				Exec:        execMock,
+				OS:          osMock,
+				Config:      config.ConfigStub{},
+				checkUpdate: checkFoUpdateMock,
+				isDeployed: func(ed ExecDep) error {
+					return fmt.Errorf("")
+				},
+			},
+			stdout: "",
+			isErr:  false,
+		},
+		{
+			name: "local deploy",
+			input: &DeployOptions{
+				Path:        dir,
+				Exec:        execMock,
+				OS:          osMock,
+				Config:      config.ConfigStub{},
+				checkUpdate: checkFoUpdateMock,
+				isDeployed: func(ed ExecDep) error {
+					return nil
+				},
+			},
+			stdout: "",
+			isErr:  false,
+		},
+		{
+			name: "local deploy",
+			input: &DeployOptions{
+				Path:        "a/path/does/not/exist",
+				Exec:        execMock,
+				OS:          osMock,
+				Config:      config.ConfigStub{},
+				checkUpdate: checkFoUpdateMock,
+				isDeployed: func(ed ExecDep) error {
+					return nil
+				},
+			},
+			stdout: "",
+			isErr:  true,
 		},
 	}
 

--- a/pkg/cmd/local/status.go
+++ b/pkg/cmd/local/status.go
@@ -87,7 +87,7 @@ func runStatus(opts *StatusOptions) error {
 	}
 
 	p(opts.IO, `
-		Status of the local Instill Core instance
+		Status of the local Instill Core instance:
 
 		Deployed: %s
 		Started: %s
@@ -108,10 +108,9 @@ func isDeployed(execDep ExecDep) error {
 	var checkList = make([]bool, len(projs))
 	for i := range checkList {
 		proj := strings.ToLower(projs[i])
-		if _, err := execCmd(execDep, "bash", "-c", fmt.Sprintf("docker compose ls -a | grep instill-%s", proj)); err != nil {
-			continue
+		if _, err := execCmd(execDep, "bash", "-c", fmt.Sprintf("docker compose ls -a | grep instill-%s", proj)); err == nil {
+			checkList[i] = true
 		}
-		checkList[i] = true
 	}
 
 	suiteCheck := 0

--- a/pkg/cmd/local/undeploy.go
+++ b/pkg/cmd/local/undeploy.go
@@ -1,0 +1,127 @@
+package local
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+
+	"github.com/instill-ai/cli/internal/config"
+	"github.com/instill-ai/cli/pkg/cmd/instances"
+	"github.com/instill-ai/cli/pkg/cmdutil"
+	"github.com/instill-ai/cli/pkg/iostreams"
+)
+
+// UndeployOptions contains the command line options
+type UndeployOptions struct {
+	IO             *iostreams.IOStreams
+	Exec           ExecDep
+	OS             OSDep
+	Config         config.Config
+	MainExecutable string
+	Interactive    bool
+}
+
+// NewUndeployCmd creates a new command
+func NewUndeployCmd(f *cmdutil.Factory, runF func(*UndeployOptions) error) *cobra.Command {
+	opts := &UndeployOptions{
+		IO: f.IOStreams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "undeploy",
+		Short: "Undeploy a local Instill Core instance",
+		Example: heredoc.Doc(`
+			$ inst local undeploy
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+			opts.Config = cfg
+
+			if opts.IO.CanPrompt() {
+				opts.Interactive = true
+			}
+
+			opts.MainExecutable = f.Executable()
+			if runF != nil {
+				return runF(opts)
+			}
+
+			return runUndeploy(opts)
+		},
+	}
+
+	return cmd
+}
+
+func runUndeploy(opts *UndeployOptions) error {
+
+	path, err := getConfigPath(opts.Config)
+	if err != nil {
+		return fmt.Errorf("ERROR: %w", err)
+	}
+
+	if err := isDeployed(opts.Exec); err != nil {
+		return fmt.Errorf("ERROR: %w", err)
+	}
+
+	for i := range projs {
+		proj := strings.ToLower(projs[i])
+		if opts.OS != nil {
+			err = opts.OS.Chdir(filepath.Join(path, proj))
+		} else {
+			err = os.Chdir(filepath.Join(path, proj))
+		}
+		if err != nil {
+			return fmt.Errorf("ERROR: can't open the destination, %w", err)
+		}
+		p(opts.IO, fmt.Sprintf("Tearing down Instill %s...", projs[i]))
+		out, err := execCmd(opts.Exec, "make", "down")
+		if err != nil {
+			return fmt.Errorf("ERROR: when tearing down, %w", err)
+		}
+		if err != nil {
+			return fmt.Errorf("ERROR: %s when tearing down, %w\n%s", projs[i], err, out)
+		}
+	}
+
+	p(opts.IO, "Remove local Instill Core files in: %s", path)
+	os.RemoveAll(path)
+
+	if err := unregisterInstance(opts); err != nil {
+		return err
+	}
+
+	p(opts.IO, "")
+	p(opts.IO, "Instill Core undeployed")
+
+	return nil
+}
+
+func unregisterInstance(opts *UndeployOptions) error {
+	exists, err := instances.IsInstanceAdded(opts.Config, "localhost:8080")
+	if err != nil {
+		return err
+	}
+	if exists {
+		addOpts := &instances.RemoveOptions{
+			IO:             opts.IO,
+			Config:         opts.Config,
+			MainExecutable: opts.MainExecutable,
+			Interactive:    false,
+			APIHostname:    "localhost:8080",
+		}
+		p(opts.IO, "")
+		err = instances.RunRemove(addOpts)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/local/update_test.go
+++ b/pkg/cmd/local/update_test.go
@@ -1,0 +1,34 @@
+package local
+
+import (
+	"testing"
+)
+
+func TestCheckForUpdate(t *testing.T) {
+	scenarios := []struct {
+		Name           string
+		CurrentVersion string
+		LatestVersion  string
+		LatestURL      string
+		ExpectsResult  bool
+	}{
+		{
+			Name:           "latest is newer",
+			CurrentVersion: "v0.0.1",
+			LatestVersion:  "v1.0.0",
+			LatestURL:      "https://www.spacejam.com/archive/spacejam/movie/jam.htm",
+			ExpectsResult:  true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.Name, func(t *testing.T) {
+
+			_, err := checkForUpdate(&ExecMock{}, "OWNER/REPO", s.CurrentVersion)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Because

- `local undeploy` is needed to tear down local instance

This commit

- add `local undeploy`
- move state file from `~/.local/state` to `~/.local/instill/state`
