### PR TITLE
chore(api): use explicit endpoint URL

### DIFF
--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -444,7 +444,7 @@ func Test_apiRun_inputFile(t *testing.T) {
 
 			var bodyBytes []byte
 			options := ApiOptions{
-				RequestPath:      "hello",
+				RequestPath:      "/vdp/v1alpha/hello",
 				RequestInputFile: inputFile,
 				RawFields:        []string{"a=b", "c=d"},
 
@@ -693,38 +693,4 @@ func Test_processResponse_template(t *testing.T) {
 		Alas, tis' the end (, feature)
 	`), stdout.String())
 	assert.Equal(t, "", stderr.String())
-}
-
-func TestHandleAPIPrefix(t *testing.T) {
-	tests := []struct {
-		path     string
-		version  string
-		expected string
-	}{
-		{
-			path:     "foo",
-			version:  "1",
-			expected: "vdp/1/foo",
-		},
-		{
-			path:     "model/foo",
-			version:  "1",
-			expected: "model/1/foo",
-		},
-		{
-			path:     "base/foo",
-			version:  "1",
-			expected: "base/1/foo",
-		},
-		{
-			path:     "vdp/foo",
-			version:  "1",
-			expected: "vdp/1/foo",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.version+"/"+tt.path, func(t *testing.T) {
-			assert.Equal(t, tt.expected, handleAPIPrefix(tt.path, tt.version))
-		})
-	}
 }


### PR DESCRIPTION
Because

- the API design has been changed quite a lot

This commit

- adopt the latest Instill Core API
