### PR TITLE
refactor(binary): rename instill to inst

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,4 +25,4 @@ jobs:
         run: go test -race ./...
 
       - name: Build
-        run: go build -v ./cmd/instill
+        run: go build -v ./cmd/inst

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-project_name: instill
+project_name: inst
 
 release:
   prerelease: auto
@@ -15,8 +15,8 @@ before:
 
 builds:
   - <<: &build_defaults
-      binary: bin/instill
-      main: ./cmd/instill
+      binary: bin/inst
+      main: ./cmd/inst
       ldflags:
         - -s -w
         - -X github.com/instill-ai/cli/internal/build.Version={{ .Version }}
@@ -76,16 +76,16 @@ brews:
   - tap:
       owner: instill-ai
       name: homebrew-tap
-    description: Instill AI's official command-line tool
+    description: Instill AI's command-line tool
     homepage: https://github.com/instill-ai/cli
     license: "Apache-2.0"
     commit_author:
       name: droplet-bot
       email: 70758845+droplet-bot@users.noreply.github.com
     install: |
-      bin.install "bin/instill"
-      (bash_completion/"instill").write `#{bin}/instill completion -s bash`
-      (fish_completion/"instill.fish").write `#{bin}/instill completion -s fish`
-      (zsh_completion/"_instill").write `#{bin}/instill completion -s zsh`
+      bin.install "bin/inst"
+      (bash_completion/"inst").write `#{bin}/inst completion -s bash`
+      (fish_completion/"inst.fish").write `#{bin}/inst completion -s fish`
+      (zsh_completion/"_inst").write `#{bin}/inst completion -s zsh`
     test: |
-      assert_match "instill version #{version}", shell_output("#{bin}/instill --version")
+      assert_match "inst version #{version}", shell_output("#{bin}/inst --version")

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ endif
 
 ## The following tasks delegate to `script/build.go` so they can be run cross-platform.
 
-.PHONY: bin/instill$(EXE)
-bin/instill$(EXE): script/build
+.PHONY: bin/inst$(EXE)
+bin/inst$(EXE): script/build
 	@script/build $@
 
 script/build: script/build.go
@@ -22,7 +22,7 @@ script/build: script/build.go
 .PHONY: clean
 clean:
 	rm -f script/build
-	rm -f bin/instill
+	rm -f bin/inst
 
 # just a convenience task around `go test`
 .PHONY: test
@@ -38,10 +38,10 @@ bindir  := ${prefix}/bin
 mandir  := ${prefix}/share/man
 
 .PHONY: install
-install: bin/instill
+install: bin/inst
 	install -d ${DESTDIR}${bindir}
-	install -m755 bin/instill ${DESTDIR}${bindir}/
+	install -m755 bin/inst ${DESTDIR}${bindir}/
 
 .PHONY: uninstall
 uninstall:
-	rm -f ${DESTDIR}${bindir}/instill
+	rm -f ${DESTDIR}${bindir}/inst

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@
 [![License](https://img.shields.io/github/license/instill-ai/cli.svg?color=lightblue&label=License)](./License.md)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-lightblue.svg)](.github/code_of_conduct.md)
 
-`instill` is the command line interface for **Instill Cloud**.
+`inst` is the command line interface for **Instill Core / Cloud**.
 
 ## Table of contents <!-- omit in toc -->
 - [What is Instill Cloud?](#what-is-instill-cloud)
 - [Installation](#installation)
+- [Usage examples](#usage-examples)
 - [Issues and discussions](#issues-and-discussions)
 
 ## What is Instill Cloud?
@@ -41,51 +42,37 @@ Instill AI is on a mission to make AI accessible to everyone. With **Instill Clo
 
 To install:
 ```
-brew install instill-ai/tap/instill
+brew install instill-ai/tap/inst
 ```
 
 To upgrade:
 ```
-brew upgrade instill-ai/tap/instill
+brew upgrade instill-ai/tap/inst
 ```
 
 ## Usage examples
 
 ```bash
 # log in
-$ instill auth login
+$ inst auth login
 
 # list pipelines
-$ instill api pipelines
+$ inst api pipelines
 
 # list models
-$ instill api model/models
+$ inst api model/models
 
 # add parameters to a GET request
-$ instill api model/models?visibility=public
+$ inst api model/models?visibility=public
 
 # list instances
-$ instill instances list
-
-# selected a default instance
-$ instill instances set-default my-host.com
-
-# add an instance
-$ instill instances add instill.localhost \
-    --oauth2 auth.instill.tech \
-    --audience https://instill.tech \
-    --issuer https://auth.instill.tech/ \
-    --secret YOUR_SECRET \
-    --client-id CLIENT_ID
-
-# add parameters to a POST request
-$ instill api -X POST oauth2/token?audience=...&grant_type=...
+$ inst instances list
 
 # add nested JSON body to a POST request
-$ jq -n '{"contents":[{"url": "https://artifacts.instill.tech/dog.jpg"}]}' | instill api demo/tasks/classification/outputs --input -
+$ jq -n '{"contents":[{"url": "https://artifacts.instill.tech/dog.jpg"}]}' | inst api demo/tasks/classification/outputs --input -
 
 # set a custom HTTP header
-$ instill api -H 'Authorization: Basic mytoken' ...
+$ inst api -H 'Authorization: Basic mytoken' ...
 ```
 
 ## Issues and discussions

--- a/cmd/inst/main.go
+++ b/cmd/inst/main.go
@@ -87,7 +87,7 @@ func mainRun() exitCode {
 		}
 	}
 
-	// Enable running instill from Windows File Explorer's address bar. Without this, the user is told to stop and run from a
+	// Enable running inst from Windows File Explorer's address bar. Without this, the user is told to stop and run from a
 	// terminal. With this, a user can clone a repo (or take other actions) directly from explorer.
 	if len(os.Args) > 1 && os.Args[1] != "" {
 		cobra.MousetrapHelpText = ""
@@ -106,7 +106,7 @@ func mainRun() exitCode {
 		expandedArgs = os.Args[1:]
 	}
 
-	// translate `instill help <command>` to `instill <command> --help` for extensions
+	// translate `inst help <command>` to `inst <command> --help` for extensions
 	if len(expandedArgs) == 2 && expandedArgs[0] == "help" && !hasCommand(rootCmd, expandedArgs[1:]) {
 		expandedArgs = []string{expandedArgs[1], "--help"}
 	}
@@ -119,7 +119,7 @@ func mainRun() exitCode {
 		if cmdutil.IsAuthCheckEnabled(cmd) && !cmdutil.CheckAuth(cfg) {
 			fmt.Fprintln(stderr, cs.Bold("Welcome to Instill CLI!"))
 			fmt.Fprintln(stderr)
-			fmt.Fprintln(stderr, "To authenticate, please run `instill auth login`.")
+			fmt.Fprintln(stderr, "To authenticate, please run `inst auth login`.")
 			return authError
 		}
 
@@ -145,13 +145,13 @@ func mainRun() exitCode {
 
 		if strings.Contains(err.Error(), "Incorrect function") {
 			fmt.Fprintln(stderr, "You appear to be running in MinTTY without pseudo terminal support.")
-			fmt.Fprintln(stderr, "To learn about workarounds for this error, run:  instill help mintty")
+			fmt.Fprintln(stderr, "To learn about workarounds for this error, run:  inst help mintty")
 			return exitError
 		}
 
 		var httpErr api.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == 401 {
-			fmt.Fprintln(stderr, "Try authenticating with:  instill auth login")
+			fmt.Fprintln(stderr, "Try authenticating with:  inst auth login")
 		}
 
 		return exitError
@@ -172,7 +172,7 @@ func mainRun() exitCode {
 			ansi.Color(buildVersion, "cyan"),
 			ansi.Color(newRelease.Version, "cyan"))
 		if isHomebrew {
-			fmt.Fprintf(stderr, "To upgrade, run: %s\n", "brew update && brew upgrade instill")
+			fmt.Fprintf(stderr, "To upgrade, run: %s\n", "brew update && brew upgrade inst")
 		}
 		fmt.Fprintf(stderr, "%s\n\n",
 			ansi.Color(newRelease.URL, "yellow"))
@@ -265,7 +265,7 @@ func isRecentRelease(publishedAt time.Time) bool {
 	return !publishedAt.IsZero() && time.Since(publishedAt) < time.Hour*24
 }
 
-// Check whether the instill binary was found under the Homebrew prefix
+// Check whether the inst binary was found under the Homebrew prefix
 func isUnderHomebrew(instillBinary string) bool {
 	brewExe, err := safeexec.LookPath("brew")
 	if err != nil {

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -31,12 +31,12 @@ func ConfigDir() string {
 	if a := os.Getenv(INSTILL_CONFIG_DIR); a != "" {
 		path = a
 	} else if b := os.Getenv(XDG_CONFIG_HOME); b != "" {
-		path = filepath.Join(b, "instill")
+		path = filepath.Join(b, "inst")
 	} else if c := os.Getenv(APP_DATA); runtime.GOOS == "windows" && c != "" {
 		path = filepath.Join(c, "Instill CLI")
 	} else {
 		d, _ := os.UserHomeDir()
-		path = filepath.Join(d, ".config", "instill")
+		path = filepath.Join(d, ".config", "inst")
 	}
 
 	// If the path does not exist and the INSTILL_CONFIG_DIR flag is not set try
@@ -55,12 +55,12 @@ func ConfigDir() string {
 func StateDir() string {
 	var path string
 	if a := os.Getenv(XDG_STATE_HOME); a != "" {
-		path = filepath.Join(a, "instill")
+		path = filepath.Join(a, "inst")
 	} else if b := os.Getenv(LOCAL_APP_DATA); runtime.GOOS == "windows" && b != "" {
 		path = filepath.Join(b, "Instill CLI")
 	} else {
 		c, _ := os.UserHomeDir()
-		path = filepath.Join(c, ".local", "instill", "state")
+		path = filepath.Join(c, ".local", "inst", "state")
 	}
 
 	// If the path does not exist try migrating state from default paths
@@ -78,12 +78,12 @@ func StateDir() string {
 func DataDir() string {
 	var path string
 	if a := os.Getenv(XDG_DATA_HOME); a != "" {
-		path = filepath.Join(a, "instill")
+		path = filepath.Join(a, "inst")
 	} else if b := os.Getenv(LOCAL_APP_DATA); runtime.GOOS == "windows" && b != "" {
 		path = filepath.Join(b, "Instill CLI")
 	} else {
 		c, _ := os.UserHomeDir()
-		path = filepath.Join(c, ".local", "share", "instill")
+		path = filepath.Join(c, ".local", "share", "inst")
 	}
 
 	return path
@@ -96,7 +96,7 @@ var errNotExist = errors.New("not exist")
 // If configs exist then move them to newPath
 func autoMigrateConfigDir(newPath string) error {
 	path, err := os.UserHomeDir()
-	if oldPath := filepath.Join(path, ".config", "instill"); err == nil && dirExists(oldPath) {
+	if oldPath := filepath.Join(path, ".config", "inst"); err == nil && dirExists(oldPath) {
 		return migrateDir(oldPath, newPath)
 	}
 
@@ -107,7 +107,7 @@ func autoMigrateConfigDir(newPath string) error {
 // If state file exist then move it to newPath
 func autoMigrateStateDir(newPath string) error {
 	path, err := os.UserHomeDir()
-	if oldPath := filepath.Join(path, ".config", "instill"); err == nil && dirExists(oldPath) {
+	if oldPath := filepath.Join(path, ".config", "inst"); err == nil && dirExists(oldPath) {
 		return migrateFile(oldPath, newPath, "state.yml")
 	}
 

--- a/internal/config/config_file_test.go
+++ b/internal/config/config_file_test.go
@@ -174,29 +174,29 @@ func Test_ConfigDir(t *testing.T) {
 				"USERPROFILE":        tempDir,
 				"HOME":               tempDir,
 			},
-			output: filepath.Join(tempDir, ".config", "instill"),
+			output: filepath.Join(tempDir, ".config", "inst"),
 		},
 		{
 			name: "INSTILL_CONFIG_DIR specified",
 			env: map[string]string{
-				"INSTILL_CONFIG_DIR": filepath.Join(tempDir, "instill_config_dir"),
+				"INSTILL_CONFIG_DIR": filepath.Join(tempDir, "inst_config_dir"),
 			},
-			output: filepath.Join(tempDir, "instill_config_dir"),
+			output: filepath.Join(tempDir, "inst_config_dir"),
 		},
 		{
 			name: "XDG_CONFIG_HOME specified",
 			env: map[string]string{
 				"XDG_CONFIG_HOME": tempDir,
 			},
-			output: filepath.Join(tempDir, "instill"),
+			output: filepath.Join(tempDir, "inst"),
 		},
 		{
 			name: "INSTILL_CONFIG_DIR and XDG_CONFIG_HOME specified",
 			env: map[string]string{
-				"INSTILL_CONFIG_DIR": filepath.Join(tempDir, "instill_config_dir"),
+				"INSTILL_CONFIG_DIR": filepath.Join(tempDir, "inst_config_dir"),
 				"XDG_CONFIG_HOME":    tempDir,
 			},
-			output: filepath.Join(tempDir, "instill_config_dir"),
+			output: filepath.Join(tempDir, "inst_config_dir"),
 		},
 		{
 			name:        "AppData specified",
@@ -210,10 +210,10 @@ func Test_ConfigDir(t *testing.T) {
 			name:        "INSTILL_CONFIG_DIR and AppData specified",
 			onlyWindows: true,
 			env: map[string]string{
-				"INSTILL_CONFIG_DIR": filepath.Join(tempDir, "instill_config_dir"),
+				"INSTILL_CONFIG_DIR": filepath.Join(tempDir, "inst_config_dir"),
 				"AppData":            tempDir,
 			},
-			output: filepath.Join(tempDir, "instill_config_dir"),
+			output: filepath.Join(tempDir, "inst_config_dir"),
 		},
 		{
 			name:        "XDG_CONFIG_HOME and AppData specified",
@@ -222,7 +222,7 @@ func Test_ConfigDir(t *testing.T) {
 				"XDG_CONFIG_HOME": tempDir,
 				"AppData":         tempDir,
 			},
-			output: filepath.Join(tempDir, "instill"),
+			output: filepath.Join(tempDir, "inst"),
 		},
 	}
 
@@ -249,7 +249,7 @@ func Test_ConfigDir(t *testing.T) {
 }
 
 func Test_configFile_Write_toDisk(t *testing.T) {
-	configDir := filepath.Join(t.TempDir(), ".config", "instill")
+	configDir := filepath.Join(t.TempDir(), ".config", "inst")
 	_ = os.MkdirAll(configDir, 0755)
 	os.Setenv(INSTILL_CONFIG_DIR, configDir)
 	defer os.Unsetenv(INSTILL_CONFIG_DIR)
@@ -296,7 +296,7 @@ func Test_autoMigrateConfigDir_noMigration_notExist(t *testing.T) {
 
 func Test_autoMigrateConfigDir_noMigration_samePath(t *testing.T) {
 	homeDir := t.TempDir()
-	migrateDir := filepath.Join(homeDir, ".config", "instill")
+	migrateDir := filepath.Join(homeDir, ".config", "inst")
 	err := os.MkdirAll(migrateDir, 0755)
 	assert.NoError(t, err)
 
@@ -319,8 +319,8 @@ func Test_autoMigrateConfigDir_noMigration_samePath(t *testing.T) {
 func Test_autoMigrateConfigDir_migration(t *testing.T) {
 	homeDir := t.TempDir()
 	migrateDir := t.TempDir()
-	homeConfigDir := filepath.Join(homeDir, ".config", "instill")
-	migrateConfigDir := filepath.Join(migrateDir, ".config", "instill")
+	homeConfigDir := filepath.Join(homeDir, ".config", "inst")
+	migrateConfigDir := filepath.Join(migrateDir, ".config", "inst")
 
 	homeEnvVar := "HOME"
 	if runtime.GOOS == "windows" {
@@ -366,14 +366,14 @@ func Test_StateDir(t *testing.T) {
 				"USERPROFILE":        tempDir,
 				"HOME":               tempDir,
 			},
-			output: filepath.Join(tempDir, ".local", "instill", "state"),
+			output: filepath.Join(tempDir, ".local", "inst", "state"),
 		},
 		{
 			name: "XDG_STATE_HOME specified",
 			env: map[string]string{
 				"XDG_STATE_HOME": tempDir,
 			},
-			output: filepath.Join(tempDir, "instill"),
+			output: filepath.Join(tempDir, "inst"),
 		},
 		{
 			name:        "LocalAppData specified",
@@ -390,7 +390,7 @@ func Test_StateDir(t *testing.T) {
 				"XDG_STATE_HOME": tempDir,
 				"LocalAppData":   tempDir,
 			},
-			output: filepath.Join(tempDir, "instill"),
+			output: filepath.Join(tempDir, "inst"),
 		},
 	}
 
@@ -438,7 +438,7 @@ func Test_autoMigrateStateDir_noMigration_notExist(t *testing.T) {
 
 func Test_autoMigrateStateDir_noMigration_samePath(t *testing.T) {
 	homeDir := t.TempDir()
-	migrateDir := filepath.Join(homeDir, ".config", "instill")
+	migrateDir := filepath.Join(homeDir, ".config", "inst")
 	err := os.MkdirAll(migrateDir, 0755)
 	assert.NoError(t, err)
 
@@ -461,8 +461,8 @@ func Test_autoMigrateStateDir_noMigration_samePath(t *testing.T) {
 func Test_autoMigrateStateDir_migration(t *testing.T) {
 	homeDir := t.TempDir()
 	migrateDir := t.TempDir()
-	homeConfigDir := filepath.Join(homeDir, ".config", "instill")
-	migrateStateDir := filepath.Join(migrateDir, ".local", "instill")
+	homeConfigDir := filepath.Join(homeDir, ".config", "inst")
+	migrateStateDir := filepath.Join(migrateDir, ".local", "inst")
 
 	homeEnvVar := "HOME"
 	if runtime.GOOS == "windows" {
@@ -509,14 +509,14 @@ func Test_DataDir(t *testing.T) {
 				"USERPROFILE":        tempDir,
 				"HOME":               tempDir,
 			},
-			output: filepath.Join(tempDir, ".local", "share", "instill"),
+			output: filepath.Join(tempDir, ".local", "share", "inst"),
 		},
 		{
 			name: "XDG_DATA_HOME specified",
 			env: map[string]string{
 				"XDG_DATA_HOME": tempDir,
 			},
-			output: filepath.Join(tempDir, "instill"),
+			output: filepath.Join(tempDir, "inst"),
 		},
 		{
 			name:        "LocalAppData specified",
@@ -533,7 +533,7 @@ func Test_DataDir(t *testing.T) {
 				"XDG_DATA_HOME": tempDir,
 				"LocalAppData":  tempDir,
 			},
-			output: filepath.Join(tempDir, "instill"),
+			output: filepath.Join(tempDir, "inst"),
 		},
 	}
 

--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// This interface describes interacting with some persistent configuration for instill.
+// Config is the interface describes interacting with some persistent configuration for inst.
 type Config interface {
 	Get(string, string) (string, error)
 	GetWithSource(string, string) (string, string, error)
@@ -146,7 +146,7 @@ func NewBlankRoot() *yaml.Node {
 						Value: "https",
 					},
 					{
-						HeadComment: "What editor instill should run. If blank, will refer to environment.",
+						HeadComment: "What editor inst should run. If blank, will refer to environment.",
 						Kind:        yaml.ScalarNode,
 						Value:       "editor",
 					},
@@ -182,7 +182,7 @@ func NewBlankRoot() *yaml.Node {
 						Value: "",
 					},
 					{
-						HeadComment: "What web browser instill should use when opening URLs. If blank, will refer to environment.",
+						HeadComment: "What web browser inst should use when opening URLs. If blank, will refer to environment.",
 						Kind:        yaml.ScalarNode,
 						Value:       "browser",
 					},

--- a/internal/config/config_type_test.go
+++ b/internal/config/config_type_test.go
@@ -41,7 +41,7 @@ func Test_defaultConfig(t *testing.T) {
 	expected := heredoc.Doc(`
 		# What protocol to use when performing git operations. Supported values: https
 		protocol: https
-		# What editor instill should run. If blank, will refer to environment.
+		# What editor inst should run. If blank, will refer to environment.
 		editor:
 		# When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
 		prompt: enabled
@@ -49,7 +49,7 @@ func Test_defaultConfig(t *testing.T) {
 		pager:
 		# The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
 		http_unix_socket:
-		# What web browser instill should use when opening URLs. If blank, will refer to environment.
+		# What web browser inst should use when opening URLs. If blank, will refer to environment.
 		browser:
 	`)
 	assert.Equal(t, expected, mainBuf.String())

--- a/internal/config/from_file_test.go
+++ b/internal/config/from_file_test.go
@@ -24,7 +24,7 @@ func Test_HostsTyped(t *testing.T) {
 }
 
 func Test_fileConfig_Typed(t *testing.T) {
-	configDir := filepath.Join(t.TempDir(), ".local", "instill")
+	configDir := filepath.Join(t.TempDir(), ".local", "inst")
 	_ = os.MkdirAll(configDir, 0755)
 	os.Setenv(INSTILL_CONFIG_DIR, configDir)
 	defer os.Unsetenv(INSTILL_CONFIG_DIR)

--- a/internal/run/stub.go
+++ b/internal/run/stub.go
@@ -13,7 +13,7 @@ type T interface {
 	Errorf(string, ...interface{})
 }
 
-// Stub installs a catch-all for all external commands invoked from instill. It returns a restore func that, when
+// Stub installs a catch-all for all external commands invoked from inst. It returns a restore func that, when
 // invoked from tests, fails the current test if some stubs that were registered were never matched.
 func Stub() (*CommandStubber, func(T)) {
 	cs := &CommandStubber{}

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -105,22 +105,22 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command 
 		`, "`"),
 		Example: heredoc.Doc(`
 			# list pipelines
-			$ instill api vdp/v1alpha/pipelines
+			$ inst api vdp/v1alpha/pipelines
 
 			# list models
-			$ instill api model/v1alpha/models
+			$ inst api model/v1alpha/models
 
 			# get user profile
-			$ instill api base/v1alpha/users/me
+			$ inst api base/v1alpha/users/me
 
 			# add parameters to a GET request
-			$ instill api model/v1alpha/models?visibility=public
+			$ inst api model/v1alpha/models?visibility=public
 
 			# add nested JSON body to a POST request
-			$ jq -n '{"inputs":[{"image": <your image base64 encoded string>}]}' | instill api vdp/v1alpha/pipelines/trigger --input -
+			$ jq -n '{"inputs":[{"image": <your image base64 encoded string>}]}' | inst api vdp/v1alpha/pipelines/trigger --input -
 
 			# set a custom HTTP header
-			$ instill api -H 'Authorization: Basic ...'
+			$ inst api -H 'Authorization: Basic ...'
 		`),
 		Args: cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
@@ -317,7 +317,7 @@ func processResponse(resp *http.Response, opts *ApiOptions, headersOutputStream 
 	}
 
 	if serverError != "" {
-		fmt.Fprintf(opts.IO.ErrOut, "instill: %s\n", serverError)
+		fmt.Fprintf(opts.IO.ErrOut, "inst: %s\n", serverError)
 		err = cmdutil.SilentError
 		return
 	}

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -286,7 +286,7 @@ func Test_apiRun(t *testing.T) {
 			},
 			err:    cmdutil.SilentError,
 			stdout: `{"message": "THIS IS FINE"}`,
-			stderr: "instill: THIS IS FINE (HTTP 400)\n",
+			stderr: "inst: THIS IS FINE (HTTP 400)\n",
 		},
 		{
 			name: "REST string errors",
@@ -297,7 +297,7 @@ func Test_apiRun(t *testing.T) {
 			},
 			err:    cmdutil.SilentError,
 			stdout: `{"errors": ["ALSO", "FINE"]}`,
-			stderr: "instill: ALSO\nFINE\n",
+			stderr: "inst: ALSO\nFINE\n",
 		},
 		{
 			name: "failure",
@@ -307,7 +307,7 @@ func Test_apiRun(t *testing.T) {
 			},
 			err:    cmdutil.SilentError,
 			stdout: `gateway timeout`,
-			stderr: "instill: HTTP 502\n",
+			stderr: "inst: HTTP 502\n",
 		},
 		{
 			name: "silent",
@@ -416,7 +416,7 @@ func Test_apiRun_inputFile(t *testing.T) {
 		},
 		{
 			name:          "from file",
-			inputFile:     "instill-test-file",
+			inputFile:     "inst-test-file",
 			inputContents: []byte("I WORK OUT"),
 			contentLength: 10,
 		},
@@ -500,7 +500,7 @@ func Test_apiRun_cache(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		cacheDir := filepath.Join(os.TempDir(), "instill-cli-cache")
+		cacheDir := filepath.Join(os.TempDir(), "inst-cli-cache")
 		os.RemoveAll(cacheDir)
 	})
 
@@ -551,7 +551,7 @@ func Test_parseFields(t *testing.T) {
 }
 
 func Test_magicFieldValue(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "instill-test")
+	f, err := os.CreateTemp(t.TempDir(), "inst-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -630,7 +630,7 @@ func Test_magicFieldValue(t *testing.T) {
 }
 
 func Test_openUserFile(t *testing.T) {
-	f, err := os.CreateTemp(t.TempDir(), "instill-test")
+	f, err := os.CreateTemp(t.TempDir(), "inst-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -3,17 +3,19 @@ package auth
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/instill-ai/cli/pkg/cmdutil"
+
 	authLoginCmd "github.com/instill-ai/cli/pkg/cmd/auth/login"
 	authLogoutCmd "github.com/instill-ai/cli/pkg/cmd/auth/logout"
 	authStatusCmd "github.com/instill-ai/cli/pkg/cmd/auth/status"
-	"github.com/instill-ai/cli/pkg/cmdutil"
 )
 
+// NewCmdAuth creates the `auth` command
 func NewCmdAuth(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth <command>",
 		Short: "Login and logout",
-		Long:  `Manage instill's authentication state.`,
+		Long:  `Manage authentication state.`,
 	}
 
 	cmdutil.DisableAuthCheck(cmd)

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -17,11 +17,10 @@ import (
 	"github.com/instill-ai/cli/internal/instance"
 	"github.com/instill-ai/cli/internal/oauth2"
 	"github.com/instill-ai/cli/pkg/cmd/factory"
+	"github.com/instill-ai/cli/pkg/cmd/local"
 	"github.com/instill-ai/cli/pkg/cmdutil"
 	"github.com/instill-ai/cli/pkg/iostreams"
 	"github.com/instill-ai/cli/pkg/prompt"
-
-	"github.com/instill-ai/cli/pkg/cmd/local"
 )
 
 type LoginOptions struct {
@@ -49,7 +48,7 @@ func NewCmdLogin(f *cmdutil.Factory, runF func(*LoginOptions) error) *cobra.Comm
 		`),
 		Example: heredoc.Doc(`
 			# start login
-			$ instill auth login
+			$ inst auth login
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -148,7 +147,7 @@ func loginRun(f *cmdutil.Factory, opts *LoginOptions) error {
 		e := heredoc.Docf(`ERROR: OAuth2 config isn't complete for '%s'
 
 			You can fix it with:
-			$ instill instances edit %s \
+			$ inst instances edit %s \
 				--oauth2 HOSTNAME \
 				--client-id CLIENT_ID \
 				--client-secret CLIENT_SECRET`, host.APIHostname, host.APIHostname)

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -49,7 +49,7 @@ func Test_NewCmdLogin(t *testing.T) {
 			io, stdin, _, _ := iostreams.Test()
 			f := &cmdutil.Factory{
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 				Config:     config.ConfigStubFactory,
 			}
 

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -35,10 +35,10 @@ func NewCmdLogout(f *cmdutil.Factory, runF func(*LogoutOptions) error) *cobra.Co
 			interactively or via --hostname.
 		`),
 		Example: heredoc.Doc(`
-			$ instill auth logout
+			$ inst auth logout
 			# => select what host to log out of via a prompt
 
-			$ instill auth logout --hostname api.instill.tech
+			$ inst auth logout --hostname api.instill.tech
 			# => log out of specified host
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -29,7 +29,7 @@ func NewCmdStatus(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 		Short: "View authentication status",
 		Long: heredoc.Doc(`Verifies and displays information about your authentication state.
 
-			This command will test your authentication state for each Instill host that instill knows about and
+			This command will test your authentication state for each Instill host that inst knows about and
 			report on any issues.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -66,7 +66,7 @@ func statusRun(opts *StatusOptions) error {
 	}
 	if len(hostnames) == 0 {
 		fmt.Fprintf(stderr,
-			"You are not logged into any Instill hosts. Run %s to authenticate.\n", cs.Bold("instill auth login"))
+			"You are not logged into any Instill Core/Cloud instances. Run %s to authenticate.\n", cs.Bold("inst auth login"))
 		return cmdutil.SilentError
 	}
 
@@ -94,7 +94,7 @@ func statusRun(opts *StatusOptions) error {
 
 	if !isHostnameFound {
 		fmt.Fprintf(stderr,
-			"Hostname %q not found among authenticated Instill hosts\n", opts.Hostname)
+			"Hostname %q not found among authenticated Instill Core/Cloud hosts\n", opts.Hostname)
 		return cmdutil.SilentError
 	}
 

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -33,13 +33,13 @@ func NewCmdCompletion(io *iostreams.IOStreams) *cobra.Command {
 
 			After, add this to your %[1]s~/.bash_profile%[1]s:
 
-				eval "$(instill completion -s bash)"
+				eval "$(inst completion -s bash)"
 
 			### zsh
 
-			Generate a %[1]s_instill%[1]s completion script and put it somewhere in your %[1]s$fpath%[1]s:
+			Generate a %[1]s_inst%[1]s completion script and put it somewhere in your %[1]s$fpath%[1]s:
 
-				instill completion -s zsh > /usr/local/share/zsh/site-functions/_instill
+				inst completion -s zsh > /usr/local/share/zsh/site-functions/_inst
 
 			Ensure that the following is present in your %[1]s~/.zshrc%[1]s:
 
@@ -50,9 +50,9 @@ func NewCmdCompletion(io *iostreams.IOStreams) *cobra.Command {
 
 			### fish
 
-			Generate a %[1]sinstill.fish%[1]s completion script:
+			Generate a %[1]sinst.fish%[1]s completion script:
 
-				instill completion -s fish > ~/.config/fish/completions/instill.fish
+				inst completion -s fish > ~/.config/fish/completions/inst.fish
 
 			### PowerShell
 
@@ -63,7 +63,7 @@ func NewCmdCompletion(io *iostreams.IOStreams) *cobra.Command {
 
 			Add the line and save the file:
 
-				Invoke-Expression -Command $(instill completion -s powershell | Out-String)
+				Invoke-Expression -Command $(inst completion -s powershell | Out-String)
 		`, "`"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if shellType == "" {

--- a/pkg/cmd/completion/completion_test.go
+++ b/pkg/cmd/completion/completion_test.go
@@ -20,17 +20,17 @@ func TestNewCmdCompletion(t *testing.T) {
 		{
 			name:    "no arguments",
 			args:    "completion",
-			wantOut: "complete -o default -F __start_instill instill",
+			wantOut: "complete -o default -F __start_inst inst",
 		},
 		{
 			name:    "zsh completion",
 			args:    "completion -s zsh",
-			wantOut: "compdef _instill instill",
+			wantOut: "compdef _inst inst",
 		},
 		{
 			name:    "fish completion",
 			args:    "completion -s fish",
-			wantOut: "complete -c instill ",
+			wantOut: "complete -c inst",
 		},
 		{
 			name:    "PowerShell completion",
@@ -47,7 +47,7 @@ func TestNewCmdCompletion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			io, _, stdout, stderr := iostreams.Test()
 			completeCmd := NewCmdCompletion(io)
-			rootCmd := &cobra.Command{Use: "instill"}
+			rootCmd := &cobra.Command{Use: "inst"}
 			rootCmd.AddCommand(completeCmd)
 
 			argv, err := shlex.Split(tt.args)

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -15,7 +15,7 @@ import (
 
 func NewCmdConfig(f *cmdutil.Factory) *cobra.Command {
 	longDoc := strings.Builder{}
-	longDoc.WriteString("Display or change configuration settings for instill.\n\n")
+	longDoc.WriteString("Display or change configuration settings for inst.\n\n")
 	longDoc.WriteString("Current respected settings:\n")
 	for _, co := range config.ConfigOptions() {
 		longDoc.WriteString(fmt.Sprintf("- %s: %s", co.Key, co.Description))
@@ -27,7 +27,7 @@ func NewCmdConfig(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "config <command>",
-		Short: "Manage configuration for instill",
+		Short: "Manage configuration for inst",
 		Long:  longDoc.String(),
 	}
 

--- a/pkg/cmd/config/get/get.go
+++ b/pkg/cmd/config/get/get.go
@@ -28,7 +28,7 @@ func NewCmdConfigGet(f *cmdutil.Factory, runF func(*GetOptions) error) *cobra.Co
 		Use:   "get <key>",
 		Short: "Print the value of a given configuration key",
 		Example: heredoc.Doc(`
-			$ instill config get protocol
+			$ inst config get protocol
 			https
 		`),
 		Args: cobra.ExactArgs(1),

--- a/pkg/cmd/config/set/set.go
+++ b/pkg/cmd/config/set/set.go
@@ -31,10 +31,10 @@ func NewCmdConfigSet(f *cmdutil.Factory, runF func(*SetOptions) error) *cobra.Co
 		Use:   "set <key> <value>",
 		Short: "Update configuration with a value for the given key",
 		Example: heredoc.Doc(`
-			$ instill config set editor vim
-			$ instill config set editor "code --wait"
-			$ instill config set protocol ssh --host github.com
-			$ instill config set prompt disabled
+			$ inst config set editor vim
+			$ inst config set editor "code --wait"
+			$ inst config set protocol ssh --host github.com
+			$ inst config set prompt disabled
 		`),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/factory/default.go
+++ b/pkg/cmd/factory/default.go
@@ -21,7 +21,7 @@ func New(appVersion string) *cmdutil.Factory {
 			if exe != "" {
 				return exe
 			}
-			exe = executable("instill")
+			exe = executable("inst")
 			return exe
 		},
 	}
@@ -73,17 +73,17 @@ func browserLauncher(f *cmdutil.Factory) string {
 // PATH, return the absolute location to the program.
 //
 // The idea is that the result of this function is callable in the future and refers to the same
-// installation of instill, even across upgrades. This is needed primarily for Homebrew, which installs software
-// under a location such as `/usr/local/Cellar/instill/1.13.1/bin/instill` and symlinks it from `/usr/local/bin/instill`.
+// installation of inst, even across upgrades. This is needed primarily for Homebrew, which installs software
+// under a location such as `/usr/local/Cellar/inst/1.13.1/bin/inst` and symlinks it from `/usr/local/bin/inst`.
 // When the version is upgraded, Homebrew will often delete older versions, but keep the symlink. Because of
-// this, we want to refer to the `instill` binary as `/usr/local/bin/instill` and not as its internal Homebrew
+// this, we want to refer to the `inst` binary as `/usr/local/bin/inst` and not as its internal Homebrew
 // location.
 //
-// None of this would be needed if we could just refer to Instill CLI as `instill`, i.e. without using an absolute
+// None of this would be needed if we could just refer to Instill CLI as `inst`, i.e. without using an absolute
 // path. However, for some reason Homebrew does not include `/usr/local/bin` in PATH when it invokes git
-// commands to update its taps. If `instill` (no path) is being used as git credential helper, as set up by `instill
+// commands to update its taps. If `inst` (no path) is being used as git credential helper, as set up by `inst
 // auth login`, running `brew update` will print out authentication errors as git is unable to locate
-// Homebrew-installed `instill`.
+// Homebrew-installed `inst`.
 func executable(fallbackName string) string {
 	exe, err := os.Executable()
 	if err != nil {

--- a/pkg/cmd/instances/add_test.go
+++ b/pkg/cmd/instances/add_test.go
@@ -63,7 +63,7 @@ func TestInstancesAddCmd(t *testing.T) {
 					return config.ConfigStub{}, nil
 				},
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 			}
 
 			io.SetStdoutTTY(true)

--- a/pkg/cmd/instances/edit_test.go
+++ b/pkg/cmd/instances/edit_test.go
@@ -63,7 +63,7 @@ func TestInstancesEditCmd(t *testing.T) {
 					return config.ConfigStub{}, nil
 				},
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 			}
 
 			io.SetStdoutTTY(true)

--- a/pkg/cmd/instances/list_test.go
+++ b/pkg/cmd/instances/list_test.go
@@ -37,7 +37,7 @@ func TestInstancesListCmd(t *testing.T) {
 					return config.ConfigStub{}, nil
 				},
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 			}
 
 			io.SetStdoutTTY(true)

--- a/pkg/cmd/instances/remove_test.go
+++ b/pkg/cmd/instances/remove_test.go
@@ -50,7 +50,7 @@ func TestInstancesRemoveCmd(t *testing.T) {
 					return config.ConfigStub{}, nil
 				},
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 			}
 
 			io.SetStdoutTTY(true)

--- a/pkg/cmd/instances/set_default_test.go
+++ b/pkg/cmd/instances/set_default_test.go
@@ -50,7 +50,7 @@ func TestInstancesSetDefaultCmd(t *testing.T) {
 					return config.ConfigStub{}, nil
 				},
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 			}
 
 			io.SetStdoutTTY(true)

--- a/pkg/cmd/local/deploy.go
+++ b/pkg/cmd/local/deploy.go
@@ -36,7 +36,7 @@ type DeployOptions struct {
 	Config         config.Config
 	MainExecutable string
 	Interactive    bool
-	Path           string `validate:"required,dirpath" example:"/home/instill-core/"`
+	Path           string `validate:"required,dirpath" example:"/home/inst"`
 	checkUpdate    func(ExecDep, string, string) (*releaseInfo, error)
 	isDeployed     func(ExecDep) error
 }
@@ -53,8 +53,8 @@ func NewDeployCmd(f *cmdutil.Factory, runF func(*DeployOptions) error) *cobra.Co
 		Use:   "deploy",
 		Short: "Deploy a local Instill Core instance",
 		Example: heredoc.Doc(`
-			# deploy to /home/me/instill
-			$ inst local deploy --path /home/me/instill
+			# deploy to /home/me/inst
+			$ inst local deploy --path /home/me/inst
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()
@@ -79,7 +79,7 @@ func NewDeployCmd(f *cmdutil.Factory, runF func(*DeployOptions) error) *cobra.Co
 	if err != nil {
 		logger.Error("Couldn't get Home directory", err)
 	}
-	dir := filepath.Join(d, ".local", "instill") + string(os.PathSeparator)
+	dir := filepath.Join(d, ".local", "inst") + string(os.PathSeparator)
 	cmd.Flags().StringVarP(&opts.Path, "path", "p", dir, "Destination directory")
 
 	return cmd

--- a/pkg/cmd/local/deploy_test.go
+++ b/pkg/cmd/local/deploy_test.go
@@ -20,7 +20,7 @@ func TestLocalDeployCmd(t *testing.T) {
 	if err != nil {
 		logger.Error("Couldn't get home directory", err)
 	}
-	dir := filepath.Join(d, ".local", "instill") + string(os.PathSeparator)
+	dir := filepath.Join(d, ".local", "inst") + string(os.PathSeparator)
 	tests := []struct {
 		name     string
 		stdin    string
@@ -55,7 +55,7 @@ func TestLocalDeployCmd(t *testing.T) {
 					return config.ConfigStub{}, nil
 				},
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 			}
 
 			io.SetStdoutTTY(true)
@@ -102,7 +102,7 @@ func TestLocalDeployCmdRun(t *testing.T) {
 	if err != nil {
 		logger.Error("Couldn't get home directory", err)
 	}
-	dir := filepath.Join(d, ".local", "instill") + string(os.PathSeparator)
+	dir := filepath.Join(d, ".local", "inst") + string(os.PathSeparator)
 	tests := []struct {
 		name     string
 		input    *DeployOptions

--- a/pkg/cmd/local/start_test.go
+++ b/pkg/cmd/local/start_test.go
@@ -37,7 +37,7 @@ func TestLocalStartCmd(t *testing.T) {
 					return config.ConfigStub{}, nil
 				},
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 			}
 
 			io.SetStdoutTTY(true)

--- a/pkg/cmd/local/status_test.go
+++ b/pkg/cmd/local/status_test.go
@@ -37,7 +37,7 @@ func TestLocalStatusCmd(t *testing.T) {
 					return config.ConfigStub{}, nil
 				},
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 			}
 
 			io.SetStdoutTTY(true)

--- a/pkg/cmd/local/stop_test.go
+++ b/pkg/cmd/local/stop_test.go
@@ -37,7 +37,7 @@ func TestLocalStopCmd(t *testing.T) {
 					return config.ConfigStub{}, nil
 				},
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 			}
 
 			io.SetStdoutTTY(true)

--- a/pkg/cmd/local/undeploy_test.go
+++ b/pkg/cmd/local/undeploy_test.go
@@ -37,7 +37,7 @@ func TestLocalUndeployCmd(t *testing.T) {
 					return config.ConfigStub{}, nil
 				},
 				IOStreams:  io,
-				Executable: func() string { return "/path/to/instill" },
+				Executable: func() string { return "/path/to/inst" },
 			}
 
 			io.SetStdoutTTY(true)

--- a/pkg/cmd/root/help.go
+++ b/pkg/cmd/root/help.go
@@ -127,7 +127,7 @@ func rootHelpFunc(f *cmdutil.Factory, command *cobra.Command, args []string) {
 	}
 	if longText != "" && command.LocalFlags().Lookup("jq") != nil {
 		longText = strings.TrimRight(longText, "\n") +
-			"\n\nFor more information about output formatting flags, see `instill help formatting`."
+			"\n\nFor more information about output formatting flags, see `inst help formatting`."
 	}
 
 	helpEntries := []helpEntry{}
@@ -163,8 +163,8 @@ func rootHelpFunc(f *cmdutil.Factory, command *cobra.Command, args []string) {
 		helpEntries = append(helpEntries, helpEntry{"ENVIRONMENT VARIABLES", command.Annotations["help:environment"]})
 	}
 	helpEntries = append(helpEntries, helpEntry{"LEARN MORE", `
-Use 'instill <command> <subcommand> --help' for more information about a command.
-Read the manual at https://docs.instill.tech`})
+Use 'inst <command> <subcommand> --help' for more information about a command.
+Read the manual at https://www.instill.tech/docs`})
 	if _, ok := command.Annotations["help:feedback"]; ok {
 		helpEntries = append(helpEntries, helpEntry{"FEEDBACK", command.Annotations["help:feedback"]})
 	}

--- a/pkg/cmd/root/help_reference.go
+++ b/pkg/cmd/root/help_reference.go
@@ -39,7 +39,7 @@ func referenceHelpFn(io *iostreams.IOStreams) func(*cobra.Command, []string) {
 }
 
 func referenceLong(cmd *cobra.Command) string {
-	buf := bytes.NewBufferString("# instill reference\n\n")
+	buf := bytes.NewBufferString("# inst reference\n\n")
 	for _, c := range cmd.Commands() {
 		if c.Hidden {
 			continue

--- a/pkg/cmd/root/help_test.go
+++ b/pkg/cmd/root/help_test.go
@@ -12,8 +12,8 @@ func TestDedent(t *testing.T) {
 
 	cases := []c{
 		{
-			input:    "      --help      Show help for command\n      --version   Show instill version\n",
-			expected: "--help      Show help for command\n--version   Show instill version\n",
+			input:    "      --help      Show help for command\n      --version   Show inst version\n",
+			expected: "--help      Show help for command\n--version   Show inst version\n",
 		},
 		{
 			input:    "      --help              Show help for command\n  -R, --repo OWNER/REPO   Select another repository using the OWNER/REPO format\n",

--- a/pkg/cmd/root/help_topic.go
+++ b/pkg/cmd/root/help_topic.go
@@ -9,13 +9,13 @@ import (
 
 var HelpTopics = map[string]map[string]string{
 	"mintty": {
-		"short": "Information about using instill with MinTTY",
+		"short": "Information about using inst with MinTTY",
 		"long": heredoc.Doc(`
 			MinTTY is the terminal emulator that comes by default with Git
-			for Windows.  It has known issues with instill's ability to prompt a
+			for Windows.  It has known issues with inst's ability to prompt a
 			user for input.
 
-			There are a few workarounds to make instill work with MinTTY:
+			There are a few workarounds to make inst work with MinTTY:
 
 			- Reinstall Git for Windows, checking "Enable experimental support for pseudo consoles".
 
@@ -23,12 +23,12 @@ var HelpTopics = map[string]map[string]string{
 			  You can run "C:\Program Files\Git\bin\bash.exe" from any terminal emulator to continue
 			  using all of the tooling in Git For Windows without MinTTY.
 
-			- Prefix invocations of instill with winpty, eg: "winpty instill auth login".
+			- Prefix invocations of inst with winpty, eg: "winpty inst auth login".
 			  NOTE: this can lead to some UI bugs.
 		`),
 	},
 	"environment": {
-		"short": "Environment variables that can be used with instill",
+		"short": "Environment variables that can be used with inst",
 		"long": heredoc.Doc(`
 			INSTILL_EDITOR, GIT_EDITOR, VISUAL, EDITOR (in order of precedence): the editor tool to use
 			for authoring text.
@@ -56,21 +56,21 @@ var HelpTopics = map[string]map[string]string{
 			available in the viewport. When the value is a percentage, it will be applied against
 			the number of columns available in the current viewport.
 
-			INSTILL_NO_UPDATE_NOTIFIER: set to any value to disable update notifications. By default, instill
+			INSTILL_NO_UPDATE_NOTIFIER: set to any value to disable update notifications. By default, inst
 			checks for new releases once every 24 hours and displays an upgrade notice on standard
 			error if a newer version was found.
 
-			INSTILL_CONFIG_DIR: the directory where instill will store configuration files. Default:
-			"$XDG_CONFIG_HOME/instill" or "$HOME/.config/instill".
+			INSTILL_CONFIG_DIR: the directory where inst will store configuration files. Default:
+			"$XDG_CONFIG_HOME/inst" or "$HOME/.config/inst".
 		`),
 	},
 	"reference": {
-		"short": "A comprehensive reference of all instill commands",
+		"short": "A comprehensive reference of all inst commands",
 	},
 	"formatting": {
-		"short": "Formatting options for JSON data exported from instill",
+		"short": "Formatting options for JSON data exported from inst",
 		"long": heredoc.Docf(`
-			Some instill commands support exporting the data as JSON as an alternative to their usual
+			Some inst commands support exporting the data as JSON as an alternative to their usual
 			line-based plain text output. This is suitable for passing structured data to scripts.
 			The JSON output is enabled with the %[1]s--json%[1]s option, followed by the list of fields
 			to fetch. Use the flag without a value to get the list of available fields.
@@ -95,19 +95,9 @@ var HelpTopics = map[string]map[string]string{
 			- %[1]struncate <length> <input>%[1]s: ensures input fits within length
 		`, "`"),
 		"example": heredoc.Doc(`
-			# format issues as table
-			$ instill issue list --json number,title --template \
-			  '{{range .}}{{tablerow (printf "#%v" .number | autocolor "green") .title}}{{end}}'
-
-			# format a pull request using multiple tables with headers
-			$ instill pr view 3519 --json number,title,body,reviews,assignees --template \
-			  '{{printf "#%v" .number}} {{.title}}
-
-			  {{.body}}
-
-			  {{tablerow "ASSIGNEE" "NAME"}}{{range .assignees}}{{tablerow .login .name}}{{end}}{{tablerender}}
-			  {{tablerow "REVIEWER" "STATE" "COMMENT"}}{{range .reviews}}{{tablerow .author.login .state .body}}{{end}}
-			  '
+			# format pipelines as a table
+			$ inst api vdp/v1alpha/pipelines \
+			  --template '{{range .pipelines}}{{tablerow (printf "%v" .name | autocolor "green")}}{{end}}'
 		`),
 	},
 }
@@ -121,7 +111,7 @@ func NewHelpTopic(topic string) *cobra.Command {
 		Hidden:  true,
 		Annotations: map[string]string{
 			"markdown:generate": "true",
-			"markdown:basename": "instill_help_" + topic,
+			"markdown:basename": "inst_help_" + topic,
 		},
 	}
 
@@ -140,6 +130,6 @@ func helpTopicHelpFunc(command *cobra.Command, args []string) {
 }
 
 func helpTopicUsageFunc(command *cobra.Command) error {
-	command.Printf("Usage: instill help %s", command.Use)
+	command.Printf("Usage: inst help %s", command.Use)
 	return nil
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -21,23 +21,23 @@ import (
 // NewCmdRoot initiates the Cobra command root
 func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "instill <command> <subcommand> [flags]",
+		Use:   "inst <command> <subcommand> [flags]",
 		Short: "Instill CLI",
-		Long:  `Access Instill services from the command line.`,
+		Long:  `Access Instill Core/Cloud from the command line.`,
 
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Example: heredoc.Doc(`
-			$ instill api pipelines
-			$ instill config get editor
-			$ instill auth login
+			$ inst api pipelines
+			$ inst config get editor
+			$ inst auth login
 		`),
 		Annotations: map[string]string{
 			"help:feedback": heredoc.Doc(`
 				Please open an issue on https://github.com/instill-ai/cli.
 			`),
 			"help:environment": heredoc.Doc(`
-				See 'instill help environment' for the list of supported environment variables.
+				See 'inst help environment' for the list of supported environment variables.
 			`),
 		},
 	}
@@ -55,7 +55,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	formattedVersion := versionCmd.Format(version, buildDate)
 	cmd.SetVersionTemplate(formattedVersion)
 	cmd.Version = formattedVersion
-	cmd.Flags().Bool("version", false, "Show instill version")
+	cmd.Flags().Bool("version", false, "Show inst version")
 
 	// Child commands
 	cmd.AddCommand(versionCmd.NewCmdVersion(f, version, buildDate))

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -33,7 +33,7 @@ func Format(version, buildDate string) string {
 		dateStr = fmt.Sprintf(" (%s)", buildDate)
 	}
 
-	return fmt.Sprintf("instill version %s%s\n%s\n", version, dateStr, changelogURL(version))
+	return fmt.Sprintf("inst version %s%s\n%s\n", version, dateStr, changelogURL(version))
 }
 
 func changelogURL(version string) string {

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestFormat(t *testing.T) {
-	expects := "instill version 1.4.0 (2020-12-15)\nhttps://github.com/instill-ai/cli/releases/tag/v1.4.0\n"
+	expects := "inst version 1.4.0 (2020-12-15)\nhttps://github.com/instill-ai/cli/releases/tag/v1.4.0\n"
 	if got := Format("1.4.0", "2020-12-15"); got != expects {
 		t.Errorf("Format() = %q, wants %q", got, expects)
 	}

--- a/pkg/cmdutil/auth_check_test.go
+++ b/pkg/cmdutil/auth_check_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_CheckAuth(t *testing.T) {
-	configDir := filepath.Join(t.TempDir(), ".config", "instill")
+	configDir := filepath.Join(t.TempDir(), ".config", "inst")
 	_ = os.MkdirAll(configDir, 0755)
 	os.Setenv(config.INSTILL_CONFIG_DIR, configDir)
 	defer os.Unsetenv(config.INSTILL_CONFIG_DIR)

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -18,6 +18,6 @@ type Factory struct {
 	HTTPClient func() (*http.Client, error)
 	Config     func() (config.Config, error)
 
-	// Executable is the path to the currently invoked instill binary
+	// Executable is the path to the currently invoked inst binary
 	Executable func() string
 }

--- a/script/build.go
+++ b/script/build.go
@@ -4,7 +4,7 @@
 //
 // Known tasks are:
 //
-//   bin/instill:
+//   bin/inst:
 //     Builds the main executable.
 //     Supported environment variables:
 //     - INSTILL_VERSION: determined from source by default
@@ -42,7 +42,7 @@ import (
 )
 
 var tasks = map[string]func(string) error{
-	"bin/instill": func(exe string) error {
+	"bin/inst": func(exe string) error {
 		info, err := os.Stat(exe)
 		if err == nil && !sourceFilesLaterThan(info.ModTime()) {
 			fmt.Printf("%s: `%s` is up to date.\n", self, exe)
@@ -57,7 +57,7 @@ var tasks = map[string]func(string) error{
 			ldflags = fmt.Sprintf("-X github.com/instill-ai/cli/internal/oauth2.clientSecret=%s %s", oauthSecret, ldflags)
 		}
 
-		return run("go", "build", "-trimpath", "-ldflags", ldflags, "-o", exe, "./cmd/instill")
+		return run("go", "build", "-trimpath", "-ldflags", ldflags, "-o", exe, "./cmd/inst")
 	},
 	"clean": func(_ string) error {
 		return rmrf("bin", "share")
@@ -80,9 +80,9 @@ func main() {
 
 	if len(args) < 2 {
 		if isWindowsTarget() {
-			args = append(args, filepath.Join("bin", "instill.exe"))
+			args = append(args, filepath.Join("bin", "inst.exe"))
 		} else {
-			args = append(args, "bin/instill")
+			args = append(args, "bin/inst")
 		}
 	}
 


### PR DESCRIPTION
Because

- to keep the binary name short

This commit

- rename `instill` to `inst`
