### PR TITLE
chore(local): remove deploy path argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,4 @@ install: bin/inst
 .PHONY: uninstall
 uninstall:
 	rm -f ${DESTDIR}${bindir}/inst
+	rm -f bin/inst

--- a/pkg/cmd/local/deploy.go
+++ b/pkg/cmd/local/deploy.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/safeexec"
-	"github.com/go-playground/validator/v10"
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
 
@@ -36,7 +35,7 @@ type DeployOptions struct {
 	Config         config.Config
 	MainExecutable string
 	Interactive    bool
-	Path           string `validate:"required,dirpath" example:"/home/inst"`
+	Path           string
 	checkUpdate    func(ExecDep, string, string) (*releaseInfo, error)
 	isDeployed     func(ExecDep) error
 }
@@ -53,8 +52,7 @@ func NewDeployCmd(f *cmdutil.Factory, runF func(*DeployOptions) error) *cobra.Co
 		Use:   "deploy",
 		Short: "Deploy a local Instill Core instance",
 		Example: heredoc.Doc(`
-			# deploy to /home/me/inst
-			$ inst local deploy --path /home/me/inst
+			$ inst local deploy
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := f.Config()
@@ -79,8 +77,7 @@ func NewDeployCmd(f *cmdutil.Factory, runF func(*DeployOptions) error) *cobra.Co
 	if err != nil {
 		logger.Error("Couldn't get Home directory", err)
 	}
-	dir := filepath.Join(d, ".local", "instill") + string(os.PathSeparator)
-	cmd.Flags().StringVarP(&opts.Path, "path", "p", dir, "Destination directory")
+	opts.Path = filepath.Join(d, ".local", "instill") + string(os.PathSeparator)
 
 	return cmd
 }
@@ -90,10 +87,6 @@ func runDeploy(opts *DeployOptions) error {
 	var err error
 	path := opts.Path
 	start := time.Now()
-	err = validator.New().Struct(opts)
-	if err != nil {
-		return fmt.Errorf("ERROR: wrong input, %w", err)
-	}
 
 	// check the deps
 	apps := []string{"bash", "docker", "make", "git", "jq", "grep", "curl"}

--- a/pkg/cmd/local/deploy_test.go
+++ b/pkg/cmd/local/deploy_test.go
@@ -37,14 +37,6 @@ func TestLocalDeployCmd(t *testing.T) {
 			},
 			isErr: false,
 		},
-		{
-			name:  "local deploy --path /home",
-			input: " --path /home",
-			output: DeployOptions{
-				Path: "/home",
-			},
-			isErr: false,
-		},
 	}
 
 	for _, tt := range tests {
@@ -165,11 +157,11 @@ func TestLocalDeployCmdRun(t *testing.T) {
 				Config:      config.ConfigStub{},
 				checkUpdate: checkFoUpdateMock,
 				isDeployed: func(ed ExecDep) error {
-					return nil
+					return fmt.Errorf("")
 				},
 			},
 			stdout: "",
-			isErr:  true,
+			isErr:  false,
 		},
 	}
 

--- a/pkg/cmd/local/status.go
+++ b/pkg/cmd/local/status.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/go-playground/validator/v10"
 	"github.com/spf13/cobra"
 
 	"github.com/instill-ai/cli/internal/config"
@@ -67,10 +66,6 @@ func NewStatusCmd(f *cmdutil.Factory, runF func(*StatusOptions) error) *cobra.Co
 
 // TODO separate health statuses per API
 func runStatus(opts *StatusOptions) error {
-
-	if err := validator.New().Struct(opts); err != nil {
-		return fmt.Errorf("ERROR: wrong input, %w", err)
-	}
 
 	deployed := "NO"
 	started := "NO"

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -34,7 +34,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 		`),
 		Annotations: map[string]string{
 			"help:feedback": heredoc.Doc(`
-				Please open an issue on https://github.com/instill-ai/cli.
+				Please open an issue on https://github.com/instill-ai/community.
 			`),
 			"help:environment": heredoc.Doc(`
 				See 'inst help environment' for the list of supported environment variables.


### PR DESCRIPTION
Because

- the Instill Core projects can be just cloned to a constant local folder default to `~/.local/instill`

This commit

- remove path argument for `deploy` command
- fix Makefile uninstall
- update issue url
