### PR TITLE
chore(http): revert to use http header callback for Authorization

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"os"
 	"regexp"
@@ -49,21 +48,8 @@ type ApiOptions struct {
 	HTTPClient func() (*http.Client, error)
 }
 
-var logger *slog.Logger
-
-func init() {
-	var lvl = new(slog.LevelVar)
-	if os.Getenv("DEBUG") != "" {
-		lvl.Set(slog.LevelDebug)
-	} else {
-		lvl.Set(slog.LevelError + 1)
-	}
-	logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: lvl,
-	}))
-}
-
-func NewCmdApi(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command {
+// NewCmdAPI creates a new command
+func NewCmdAPI(f *cmdutil.Factory, runF func(*ApiOptions) error) *cobra.Command {
 	opts := ApiOptions{
 		IO:         f.IOStreams,
 		Config:     f.Config,
@@ -244,13 +230,6 @@ func apiRun(opts *ApiOptions) error {
 		defer opts.IO.StopPager()
 	}
 
-	if host.AccessToken != "" {
-		requestHeaders = append(requestHeaders, "Authorization: Bearer "+host.AccessToken)
-	}
-
-	logger.Debug("api request", "host", host.APIHostname, "path", requestPath)
-
-	// http request & output
 	template := export.NewTemplate(opts.IO, opts.Template)
 	resp, err := httpRequest(httpClient, host.APIHostname, method, requestPath, requestBody, requestHeaders)
 	if err != nil {

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -197,7 +197,7 @@ func Test_NewCmdApi(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var opts *ApiOptions
-			cmd := NewCmdApi(f, func(o *ApiOptions) error {
+			cmd := NewCmdAPI(f, func(o *ApiOptions) error {
 				opts = o
 				return nil
 			})

--- a/pkg/cmd/factory/http.go
+++ b/pkg/cmd/factory/http.go
@@ -98,7 +98,7 @@ func NewHTTPClient(io *iostreams.IOStreams, cfg configHTTPClient, appVersion str
 		api.AddHeaderFunc("Authorization", func(req *http.Request) (string, error) {
 			hostname := getHost(req)
 			if accessToken, err := cfg.Get(hostname, "access_token"); err == nil && accessToken != "" {
-				// Refresh access token everytime
+				// Refresh access token every time
 				if accessToken, err = oauth2.RefreshToken(cfg, hostname); err == nil && accessToken != "" {
 					return fmt.Sprintf("bearer %s", accessToken), nil
 				}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -69,7 +69,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *cobra.Command {
 	bareHTTPCmdFactory := *f
 	bareHTTPCmdFactory.HTTPClient = bareHTTPClient(f, version)
 
-	cmd.AddCommand(apiCmd.NewCmdApi(&bareHTTPCmdFactory, nil))
+	cmd.AddCommand(apiCmd.NewCmdAPI(&bareHTTPCmdFactory, nil))
 
 	// Help topics
 	cmd.AddCommand(NewHelpTopic("environment"))


### PR DESCRIPTION
Because

- refresh token isn't refreshed when access token is expired due to the http header `Authorization` callback was overridden

This commit

- revert back to the previous logic
- enable non-blocking status checks