### PR TITLE
fix: fix default hostname when hosts.yml is empty

### DIFF
--- a/internal/config/config_type.go
+++ b/internal/config/config_type.go
@@ -11,7 +11,7 @@ type Config interface {
 	Get(string, string) (string, error)
 	GetWithSource(string, string) (string, string, error)
 	Set(string, string, string) error
-	UnsetHost(string)
+	UnsetHost(string) error
 	Hosts() ([]string, error)
 	HostsTyped() ([]HostConfigTyped, error)
 	DefaultHostname() string

--- a/internal/config/stub.go
+++ b/internal/config/stub.go
@@ -36,8 +36,8 @@ func (c ConfigStub) Hosts() ([]string, error) {
 	return nil, nil
 }
 
-func (c ConfigStub) UnsetHost(hostname string) {
-	// TODO
+func (c ConfigStub) UnsetHost(hostname string) error {
+	return nil
 }
 
 func (c ConfigStub) CheckWriteable(host, key string) error {

--- a/pkg/cmd/auth/logout/logout.go
+++ b/pkg/cmd/auth/logout/logout.go
@@ -123,7 +123,11 @@ func logoutRun(opts *LogoutOptions) error {
 	}
 
 	// TODO invalidate the token instead of removing the whole instance
-	cfg.UnsetHost(hostname)
+	err = cfg.UnsetHost(hostname)
+	if err != nil {
+		return fmt.Errorf("error unset hostname '%s' - %w", hostname, err)
+	}
+
 	err = cfg.Write()
 	if err != nil {
 		return fmt.Errorf("failed to write config, authentication configuration not updated: %w", err)

--- a/pkg/cmd/instance/remove.go
+++ b/pkg/cmd/instance/remove.go
@@ -86,7 +86,10 @@ func RunRemove(opts *RemoveOptions) error {
 		return fmt.Errorf("ERROR: instance '%s' does not exists", apiHost)
 	}
 
-	opts.Config.UnsetHost(opts.APIHostname)
+	err = opts.Config.UnsetHost(opts.APIHostname)
+	if err != nil {
+		return fmt.Errorf("error unset hostname '%s' - %w", opts.APIHostname, err)
+	}
 	err = opts.Config.Write()
 	if err != nil {
 		return fmt.Errorf("error removing hostname '%s' - %w", opts.APIHostname, err)


### PR DESCRIPTION
Because

- when `hosts.yml` is empty, the `default_hostname` value in `config.yml` should fallback to the default hostname `api.instill.tech`. 
- the bug fails `inst auth login` when the user run `inst local deploy` at the very beginning (with a fresh `inst` installed) followed by `inst local undeploy` right away, where the `default_hostname` will be left with `localhost:8080`. 
- with a fresh `inst` installed, `inst auth login` uses the default hostname `api.instill.tech`.

This commit

- fix the bug
